### PR TITLE
Add tests for collection instrument validation

### DIFF
--- a/acceptance_tests/features/load_seft_collection_instrument.feature
+++ b/acceptance_tests/features/load_seft_collection_instrument.feature
@@ -4,7 +4,19 @@ Feature: Load SEFT collection instruments
     and given survey
   So that I am assured that the right collection instrument is available for the right RU
 
-    Scenario: Load collection instrument
+  Scenario: Load collection instrument
     Given the 201803 collection exercise for the QIFDI survey has been created
     When the internal user navigates to the collection exercise details page for QIFDI 201803
     Then the user is able to load the collection instruments
+
+  Scenario: Load collection instrument wrong file type selected
+    Given the 201803 collection exercise for the QIFDI survey has been created
+    When the internal user navigates to the collection exercise details page for QIFDI 201803
+    And the internal user selects a non xlsx file
+    Then an error message is displayed to the user
+
+  Scenario: Load collection instrument wrong file type uploaded
+    Given the 201803 collection exercise for the QIFDI survey has been created
+    When the internal user navigates to the collection exercise details page for QIFDI 201803
+    And the internal user loads a non xlsx file
+    Then an error message is displayed to the user at the top of the screen

--- a/acceptance_tests/features/pages/collection_exercise_details.py
+++ b/acceptance_tests/features/pages/collection_exercise_details.py
@@ -38,6 +38,14 @@ def load_collection_instrument(test_file):
     browser.find_by_id('btn-load-ci').click()
 
 
+def select_wrong_file_type(test_file):
+    browser.driver.find_element_by_id('ciFile').send_keys(abspath(test_file))
+
+
+def get_collection_instrument_error_text():
+    return browser.driver.find_element_by_id('ciFileErrorText').text
+
+
 def get_collection_instrument_success_text():
     return browser.find_by_id('collection-instrument-success').text
 
@@ -45,3 +53,7 @@ def get_collection_instrument_success_text():
 def get_collection_instruments():
     tds = browser.find_by_id('collection-instruments-table').find_by_tag('tbody').find_by_tag('td')
     return list(map(lambda td: td.value, tds))
+
+
+def get_error_header():
+    return browser.find_by_id('error-header').text

--- a/acceptance_tests/features/steps/load_seft_collection_instruments.py
+++ b/acceptance_tests/features/steps/load_seft_collection_instruments.py
@@ -13,9 +13,31 @@ def internal_user_views_collection_exercise(_):
     collection_exercise_details.go_to('QIFDI', '201803')
 
 
+@when('the internal user selects a non xlsx file')
+def internal_user_selects_non_xlsx_file(_):
+    collection_exercise_details.select_wrong_file_type('resources/collection_instrument_files/wrong_ci_type.html')
+
+
+@when('the internal user loads a non xlsx file')
+def internal_user_uploads_non_xlsx_file(_):
+    collection_exercise_details.load_collection_instrument('resources/collection_instrument_files/wrong_ci_type.html')
+
+
 @then('the user is able to load the collection instruments')
 def load_collection_instruments(_):
     collection_exercise_details.load_collection_instrument(
         test_file='resources/collection_instrument_files/064_0001_201803.xlsx')
     success_text = collection_exercise_details.get_collection_instrument_success_text()
     assert success_text == 'Collection instrument loaded'
+
+
+@then('an error message is displayed to the user')
+def incorrect_file_type_message_shown(_):
+    error_text = collection_exercise_details.get_collection_instrument_error_text()
+    assert error_text == "Incorrect file type. Please choose a file type XLSX"
+
+
+@then('an error message is displayed to the user at the top of the screen')
+def incorrect_file_type_message_shown_at_top(_):
+    error_text = collection_exercise_details.get_error_header()
+    assert error_text == "Error: wrong file type for Collection instrument"

--- a/resources/collection_instrument_files/wrong_ci_type.html
+++ b/resources/collection_instrument_files/wrong_ci_type.html
@@ -1,0 +1,5 @@
+<html>
+  <div>
+    This isn't xlxs!
+  </div>
+</html>


### PR DESCRIPTION
Added test scenarios for collection instrument file type validation

Works with [this PR](https://github.com/ONSdigital/response-operations-ui/pull/29) in response-operations-ui

[Trello](https://trello.com/c/jyN3I43Y/58-us027-validate-collection-instrument-file-format-size-medium)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/230490136/US027+Validate+Collection+Instrument+s+Medium)