### PR TITLE
Load events before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 
 tmp_rm_tools: 
 	git clone ${RM_TOOLS_REPO_URL} tmp_rm_tools
-	cd tmp_rm_tools/collex-loader && python load.py config/collex-config.json
+	cd tmp_rm_tools/collex-loader && python load.py config/collex-config.json && python load_events.py config/event-config.json
 
 clean:
 	rm -rf tmp_rm_tools


### PR DESCRIPTION
Testing
1. Bring up docker services (use this version of rm-collection-exercise-service https://github.com/ONSdigital/rm-collection-exercise-service/pull/22)
1. Run `make clean`
1. Run `make acceptance_tests`

All tests should pass first time without having to load the events