### PR TITLE
Use pipenv for loading collection exercises and events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ install:
 
 tmp_rm_tools: 
 	git clone ${RM_TOOLS_REPO_URL} tmp_rm_tools
-	cd tmp_rm_tools/collex-loader && python load.py config/collex-config.json && python load_events.py config/event-config.json
+	pipenv run cd tmp_rm_tools/collex-loader \ # Run with pipenv to ensure python 3.6 is used
+		&& python load.py config/collex-config.json \
+		&& python load_events.py config/event-config.json
 
 clean:
 	rm -rf tmp_rm_tools

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ install:
 
 tmp_rm_tools: 
 	git clone ${RM_TOOLS_REPO_URL} tmp_rm_tools
-	pipenv run cd tmp_rm_tools/collex-loader \ # Run with pipenv to ensure python 3.6 is used
-		&& python load.py config/collex-config.json \
-		&& python load_events.py config/event-config.json
-
+	# Run with pipenv to ensure python 3.6 is used
+	cd tmp_rm_tools/collex-loader\
+	&& pipenv run python load.py config/collex-config.json\
+	&& pipenv run python load_events.py config/event-config.json
 clean:
 	rm -rf tmp_rm_tools


### PR DESCRIPTION
If a developer isn't using python 3.6.0 or a python version with out
datetime module as their global python version the make file will use
that python version. It will cause the load scripts to fail.

Wrapping the command with pipenv will use the correct version of python
given pyenv is installed