### PR TITLE
BDD us011 display state of a CE

### DIFF
--- a/acceptance_tests/features/pages/collection_exercise.py
+++ b/acceptance_tests/features/pages/collection_exercise.py
@@ -28,7 +28,8 @@ def get_collection_exercises():
     for row in rows:
         exercises.append({
             "exercise_ref": row.find_by_name('tbl-ce-period'),
-            "user_description": row.find_by_name('tbl-ce-shown-as')
+            "user_description": row.find_by_name('tbl-ce-shown-as'),
+            "state": row.find_by_name('tbl-ce-status')
         })
     return exercises
 

--- a/acceptance_tests/features/steps/view_collection_exercises_data.py
+++ b/acceptance_tests/features/steps/view_collection_exercises_data.py
@@ -42,20 +42,6 @@ def the_internal_user_can_view_all_collection_exercises_for_qbs(context):
                                                      collection_exercises))
         assert collection_exercises_by_period['exercise_ref'].value == row['period']
         assert collection_exercises_by_period['user_description'].value == row['shown_to_respondent_as']
-
-
-@then('they are able to see the status for each collection exercise')
-def they_are_able_to_see_the_status_for_each_collection_exercise(context):
-    # Validate collection exercise table headers
-    table_headers = collection_exercise.get_table_headers()
-    required_headers = ['Period', 'Shown to respondent as', 'Status']
-    assert table_headers == ' '.join(required_headers)
-
-    # Validate rows to ensure values are in the correct columns
-    collection_exercises = collection_exercise.get_collection_exercises()
-    for row in context.table:
-        collection_exercises_by_period = next(filter(lambda ce: ce['exercise_ref'].value == row['period'],
-                                                     collection_exercises))
         assert collection_exercises_by_period['state'].value == row['status']
 
 

--- a/acceptance_tests/features/steps/view_collection_exercises_data.py
+++ b/acceptance_tests/features/steps/view_collection_exercises_data.py
@@ -1,7 +1,6 @@
 from behave import given, when, then
 
 from acceptance_tests.features.pages import collection_exercise
-from acceptance_tests.features.pages import survey
 
 
 @given('collection exercises for {survey} exist in the system')

--- a/acceptance_tests/features/steps/view_collection_exercises_data.py
+++ b/acceptance_tests/features/steps/view_collection_exercises_data.py
@@ -1,6 +1,7 @@
 from behave import given, when, then
 
 from acceptance_tests.features.pages import collection_exercise
+from acceptance_tests.features.pages import survey
 
 
 @given('collection exercises for {survey} exist in the system')
@@ -32,7 +33,7 @@ def internal_user_can_view_relevant_attributes_for_qbs(context):
 def the_internal_user_can_view_all_collection_exercises_for_qbs(context):
     # Validate collection exercise table headers
     table_headers = collection_exercise.get_table_headers()
-    required_headers = ['Period', 'Shown to respondent as']
+    required_headers = ['Period', 'Shown to respondent as', 'Status']
     assert table_headers == ' '.join(required_headers)
 
     # Validate rows to ensure values are in the correct columns
@@ -42,6 +43,21 @@ def the_internal_user_can_view_all_collection_exercises_for_qbs(context):
                                                      collection_exercises))
         assert collection_exercises_by_period['exercise_ref'].value == row['period']
         assert collection_exercises_by_period['user_description'].value == row['shown_to_respondent_as']
+
+
+@then('they are able to see the status for each collection exercise')
+def they_are_able_to_see_the_status_for_each_collection_exercise(context):
+    # Validate collection exercise table headers
+    table_headers = collection_exercise.get_table_headers()
+    required_headers = ['Period', 'Shown to respondent as', 'Status']
+    assert table_headers == ' '.join(required_headers)
+
+    # Validate rows to ensure values are in the correct columns
+    collection_exercises = collection_exercise.get_collection_exercises()
+    for row in context.table:
+        collection_exercises_by_period = next(filter(lambda ce: ce['exercise_ref'].value == row['period'],
+                                                     collection_exercises))
+        assert collection_exercises_by_period['state'].value == row['status']
 
 
 @then('there is at least one collection exercise')

--- a/acceptance_tests/features/view_collection_exercises_data.feature
+++ b/acceptance_tests/features/view_collection_exercises_data.feature
@@ -13,11 +13,17 @@ Feature: View Collection Exercise
       | survey_id | survey_title              | survey_abbreviation | survey_legal_basis           |
       | 139       | Quarterly Business Survey | QBS                 | Statistics of Trade Act 1947 |
     And the internal user can view all collection exercises for QBS
-      | period | shown_to_respondent_as |
-      | 1803   | 9 March 2018           |
-      | 1806   | 15 June 2018           |
-      | 1809   | 14 September 2018      |
-      | 1812   | 14 December 2018       |
+      | period | shown_to_respondent_as | status  |
+      | 1803   | 9 March 2018           | Created |
+      | 1806   | 15 June 2018           | Created |
+      | 1809   | 14 September 2018      | Created |
+      | 1812   | 14 December 2018       | Created |
+    And they are able to see the status for each collection exercise
+      | period | shown_to_respondent_as | status  |
+      | 1803   | 9 March 2018           | Created |
+      | 1806   | 15 June 2018           | Created |
+      | 1809   | 14 September 2018      | Created |
+      | 1812   | 14 December 2018       | Created |
     And the internal user signs out
 
 

--- a/acceptance_tests/features/view_collection_exercises_data.feature
+++ b/acceptance_tests/features/view_collection_exercises_data.feature
@@ -18,12 +18,6 @@ Feature: View Collection Exercise
       | 1806   | 15 June 2018           | Created |
       | 1809   | 14 September 2018      | Created |
       | 1812   | 14 December 2018       | Created |
-    And they are able to see the status for each collection exercise
-      | period | shown_to_respondent_as | status  |
-      | 1803   | 9 March 2018           | Created |
-      | 1806   | 15 June 2018           | Created |
-      | 1809   | 14 September 2018      | Created |
-      | 1812   | 14 December 2018       | Created |
     And the internal user signs out
 
 


### PR DESCRIPTION
Added the integration tests for user story 11 displaying the state of a collection exercise

These tests wont pass currently if it is merged they are dependant on the backend stories passing data to respondent-ops ui

https://trello.com/c/kJO9QkLd