### PR TITLE
US042 Add steps for checking that the ready for review state is displayed

### DIFF
--- a/acceptance_tests/features/steps/load_sample.py
+++ b/acceptance_tests/features/steps/load_sample.py
@@ -3,6 +3,7 @@ from behave import given, when, then
 from acceptance_tests.features.pages import collection_exercise_details
 
 
+@when('the user loads the sample')
 @then('the user is able to load the sample')
 def load_sample(_):
     collection_exercise_details.load_sample()

--- a/acceptance_tests/features/steps/load_seft_collection_instruments.py
+++ b/acceptance_tests/features/steps/load_seft_collection_instruments.py
@@ -23,6 +23,7 @@ def internal_user_uploads_non_xlsx_file(_):
     collection_exercise_details.load_collection_instrument('resources/collection_instrument_files/wrong_ci_type.html')
 
 
+@when('the user loads the collection instruments')
 @then('the user is able to load the collection instruments')
 def load_collection_instruments(_):
     collection_exercise_details.load_collection_instrument(

--- a/acceptance_tests/features/view_ce_ready_for_review_state.feature
+++ b/acceptance_tests/features/view_ce_ready_for_review_state.feature
@@ -1,0 +1,17 @@
+Feature: View ready for review state of a collection exercise
+  As a Collection Exercise Coordinator
+  I need to be able to view the 'Ready for Review' state of a collection exercise
+  So that I know that all of the mandatory components of a collection exercise have been populated
+
+  Background: Internal user is already signed in
+    Given: the internal user is already signed in
+
+  @us042_s01
+  Scenario: The 'Ready for Review' state is to be displayed when a sample and collection instrument are loaded
+    Given the 201803 collection exercise for the QIFDI survey has been created
+    When the internal user navigates to the collection exercise details page for QIFDI 201803
+    And the status of the collection exercise is Scheduled
+    And the user loads the sample
+    And the user loads the collection instruments
+    Then the status of the collection exercise is Ready for Review
+    And the internal user signs out


### PR DESCRIPTION
(WIP) Waiting on PRs for displaying the [state on the details page (US011)](https://github.com/ONSdigital/response-operations-ui/pull/49) and functionality to handle the state transitions in the CE service ([US041 and US042](https://github.com/ONSdigital/rm-collection-exercise-service/pull/30)).

Ready for Review follows from a CE with events (Scheduled) after a user loads at least one CI and Sample.