### PR TITLE
tests for us046

### DIFF
--- a/acceptance_tests/features/pages/reporting_unit.py
+++ b/acceptance_tests/features/pages/reporting_unit.py
@@ -34,3 +34,21 @@ def get_associated_collection_exercises():
                 "status": row.find_by_name('tbl-ce-status').value
             })
     return exercises
+
+
+def get_associated_respondents():
+    respondents = []
+    respondents_tables = browser.find_by_name('tbl-respondents-for-survey')
+
+    for table in respondents_tables:
+        rows = table.find_by_tag('tbody').find_by_tag('tr')
+        for row in rows:
+            details = row.find_by_name('tbl-respondent-details').first
+            respondents.append({
+                "enrolementStatus": row.find_by_name('tbl-enrolment-status').value,
+                "name": details.find_by_name('tbl-respondent-name').value,
+                "email": details.find_by_name('tbl-respondent-email').value,
+                "phone": details.find_by_name('tbl-respondent-phone').value,
+                "accountStatus": details.find_by_name('tbl-respondent-status').value
+            })
+    return respondents

--- a/acceptance_tests/features/steps/view_reporting_unit_details.py
+++ b/acceptance_tests/features/steps/view_reporting_unit_details.py
@@ -35,3 +35,14 @@ def internal_internal_user_presented_correct_associated_collection_exercises(_):
     assert associated_ces[0]['company_name'] == 'RUNAME1_COMPANY1 RUNNAME2_COMPANY1'
     assert associated_ces[0]['company_region'] == 'GB'
     assert associated_ces[0]['status'] == 'Not started'
+
+
+@then('the internal user is presented with the associated respondents')
+def internal_internal_user_presented_correct_associated_respondents(_):
+    associated_respondents = reporting_unit.get_associated_respondents()
+    assert len(associated_respondents) == 1
+    assert associated_respondents[0]['enrolementStatus'] == 'Enabled'
+    assert associated_respondents[0]['name'] == 'first_name last_name'
+    assert associated_respondents[0]['email'] == 'example@example.com'
+    assert associated_respondents[0]['phone'] == '0987654321'
+    assert associated_respondents[0]['accountStatus'] == 'Created'

--- a/acceptance_tests/features/view_reporting_unit_details.feature
+++ b/acceptance_tests/features/view_reporting_unit_details.feature
@@ -24,3 +24,9 @@ Feature: View reporting unit details
     Given the reporting unit 49900000001 is in the system
     When the internal user views the 49900000001 reporting unit page
     Then the internal user is presented with the associated collection exercises
+
+  @us046_s01
+  Scenario: Able to view respondent details for the RU Ref for the survey
+    Given the reporting unit 49900000001 is in the system
+    When the internal user views the 49900000001 reporting unit page
+    Then the internal user is presented with the associated respondents


### PR DESCRIPTION
As an: internal user
I need: to be able to view respondent data for a Reporting Unit for a specific survey
So that: I understand the relationships with respondents for the Reporting Unit across surveys

Dependencies:
https://github.com/ONSdigital/ras-backstage/pull/53
https://github.com/ONSdigital/response-operations-ui/pull/55