### PR TITLE
us018 load variable event dates

### DIFF
--- a/acceptance_tests/features/pages/collection_exercise_details.py
+++ b/acceptance_tests/features/pages/collection_exercise_details.py
@@ -65,7 +65,12 @@ def get_collection_exercise_events():
         "go_live": browser.find_by_name('go-live-date').value,
         "return_by": browser.find_by_name('return-by-date').value,
         "first_reminder": browser.find_by_name('first-reminder-date').value,
-        "exercise_end": browser.find_by_name('exercise-end-date').value
+        "exercise_end": browser.find_by_name('exercise-end-date').value,
+        "ref_period_start": browser.find_by_name('period-start-date').value,
+        "ref_period_end": browser.find_by_name('period-end-date').value,
+        "employment": browser.find_by_name('employment-date').value,
+        "second_reminder": browser.find_by_name('second-reminder-date').value,
+        "third_reminder": browser.find_by_name('third-reminder-date').value
     }
     return ce_events
 

--- a/acceptance_tests/features/steps/view_collection_exercise_created_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_created_state.py
@@ -6,26 +6,26 @@ from controllers.collection_exercise_controller import get_survey_collection_exe
 
 @given('the collection exercises for that survey exist')
 def ce_exist_for_survey(_):
-    bricks_id = 'cb8accda-6118-4d3b-85a3-149e28960c54'
-    collection_exercises = get_survey_collection_exercises(bricks_id)
+    rsi_id = '75b19ea0-69a4-4c58-8d7f-4458c8f43f5c'
+    collection_exercises = get_survey_collection_exercises(rsi_id)
     assert len(collection_exercises) != 0
 
 
 @when('the internal user navigates to the survey details page')
 @given('the internal user is on the survey details page')
 def view_survey_details(_):
-    collection_exercise.go_to('Bricks')
+    collection_exercise.go_to('RSI')
 
 
 @then('the status of a collection exercise is Created')
 def survey_ce_state_is_created(_):
-    row = collection_exercise.get_table_row_by_period('201806')
+    row = collection_exercise.get_table_row_by_period('201801')
     assert row['state'] == 'Created'
 
 
 @when('the internal user navigates to the collection exercise details page')
 def view_ce_details(_):
-    collection_exercise_details.go_to('Bricks', '201806')
+    collection_exercise_details.go_to('RSI', '201801')
 
 
 @then('the displayed status should be Created')

--- a/acceptance_tests/features/steps/view_collection_exercise_details.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_details.py
@@ -9,18 +9,18 @@ def qbs_1803_exists(_):
 
 
 @given('the 1803 collection exercise events for the QBS survey has been created')
-def bres_2017_events_exist(_):
+def qbs_2018_events_exist(_):
     pass
 
 
 @given('the internal user navigates to the collection exercise details page for QBS 1803')
 @when('the internal user navigates to the collection exercise details page for QBS 1803')
-def internal_user_views_2017_bres_collection_exercise(_):
+def internal_user_views_qbs_2018_collection_exercise(_):
     collection_exercise_details.go_to('QBS', '1803')
 
 
 @then('the user is able to view the survey details and period for that survey')
-def internal_user_can_view_bres_2017_collection_exercise_details(_):
+def internal_user_can_view_qbs_2018_collection_exercise_details(_):
     ce_details = collection_exercise_details.get_collection_exercise_details()
     assert ce_details['survey_info'] == "139 QBS"
     assert ce_details['survey_title'] == "Quarterly Business Survey"
@@ -29,10 +29,20 @@ def internal_user_can_view_bres_2017_collection_exercise_details(_):
 
 
 @then('the user is able to view the event dates for that collection exercise')
-def internal_user_can_view_bres_2017_collection_exercise_events(_):
+def internal_user_can_view_qbs_2018_collection_exercise_events(_):
     ce_events = collection_exercise_details.get_collection_exercise_events()
     assert ce_events['mps'] == "Wednesday 14 Mar 2018 00:00 GMT"
     assert ce_events['go_live'] == "Monday 19 Mar 2018 00:00 GMT"
     assert ce_events['return_by'] == "Tuesday 27 Mar 2018 00:00 GMT"
-    assert ce_events['first_reminder'] == "Tuesday 08 May 2018 00:00 GMT"
+    assert ce_events['first_reminder'] == "Tuesday 03 Apr 2018 00:00 GMT"
     assert ce_events['exercise_end'] == "Thursday 30 Apr 2020 00:00 GMT"
+
+
+@then('the user is able to view the variable event dates for that collection exercise')
+def internal_user_can_view_qbs_2018_collection_exercise_variable_event_dates(_):
+    ce_events = collection_exercise_details.get_collection_exercise_events()
+    assert ce_events['ref_period_start'] == "Friday 09 Mar 2018"
+    assert ce_events['ref_period_end'] == "Saturday 31 Mar 2018"
+    assert ce_events['employment'] == "Friday 09 Mar 2018"
+    assert ce_events['second_reminder'] == "Monday 23 Apr 2018 00:00 GMT"
+    assert ce_events['third_reminder'] == "Saturday 05 May 2018 00:00 GMT"

--- a/acceptance_tests/features/view_collection_exercise_details.feature
+++ b/acceptance_tests/features/view_collection_exercise_details.feature
@@ -15,3 +15,8 @@ Feature: View collection exercise details
     Given the 1803 collection exercise for the QBS survey has been created
     When the internal user navigates to the collection exercise details page for QBS 1803
     Then the user is able to view the event dates for that collection exercise
+
+  Scenario: View collection exercise variable events
+    Given the 1803 collection exercise for the QBS survey has been created
+    When the internal user navigates to the collection exercise details page for QBS 1803
+    Then the user is able to view the variable event dates for that collection exercise

--- a/acceptance_tests/features/view_collection_exercises_data.feature
+++ b/acceptance_tests/features/view_collection_exercises_data.feature
@@ -16,8 +16,8 @@ Feature: View Collection Exercise
       | period | shown_to_respondent_as | status  |
       | 1803   | 9 March 2018           | Scheduled |
       | 1806   | 15 June 2018           | Scheduled |
-      | 1809   | 14 September 2018      | Created |
-      | 1812   | 14 December 2018       | Created |
+      | 1809   | 14 September 2018      | Scheduled |
+      | 1812   | 14 December 2018       | Scheduled |
 
 
   Scenario Outline: Ensure collection exercise exists for a survey


### PR DESCRIPTION
Tests for the load variable event dates user story 

Please test this against the changes made to RM-tools and not using `make setup`

Run load.py and load_events.py aginst the changes made in rm-tools, then run `pipenv run python set_up_ce_execution.py` and `make acceptance tests` to test against the new data. 